### PR TITLE
pypa: documentation & version updates

### DIFF
--- a/docs/pages/install.rst
+++ b/docs/pages/install.rst
@@ -1,13 +1,19 @@
 Installation
 ============
 
-Download the code, enter the interferopy folder and run
+Interferopy can be installed with ``pip``:
+
+.. code-block:: bash
+
+   pip install interferopy
+
+Alternatively, download the code, enter the interferopy folder and run
 
 .. code-block:: bash
 
     python setup.py install
 
-Or, alternatively, install directly from the repository with
+Or install directly from the repository with
 
 .. code-block:: bash
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,3 +24,4 @@ install_requires =
     matplotlib>=3.4
     tqdm>=4.62
     astropy>=4.3
+python_requires = >=3.7


### PR DESCRIPTION
Interferopy is now on pypa (https://pypi.org/project/interferopy/) and can be installed with:

`pip install interferopy`

This PR updates the documentation and adds the `python >= 3.7` requirement (consistent with the package version requirements).

